### PR TITLE
Fixes re-rendering with different props

### DIFF
--- a/VLCPlayer.js
+++ b/VLCPlayer.js
@@ -144,7 +144,7 @@ export default class VLCPlayer extends Component {
     }
 
     render() {
-        const source = resolveAssetSource(this.props.source) || {};
+        const source = resolveAssetSource({ ...this.props.source }) || {};
         let uri = source.uri || '';
         let isNetwork = !!(uri && uri.match(/^https?:/));
         const isAsset = !!(uri && uri.match(/^(assets-library|file|content|ms-appx|ms-appdata):/));


### PR DESCRIPTION
Without creating a new object out of props.source, react native may raise an error like:
`You attempted to set the key mediaOptions with the value [] on an object that is meant to be immutable and has been frozen.`

However, I suggest to move all the source setup code to componentDidMount and componentWillReceiveProps.