### PR TITLE
Avoid warning Can't update state on an unmounted component

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "type": "git",
     "url": "git+https://github.com/xuyuanzhou/react-native-yz-vlcplayer.git"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "@react-native-community/netinfo": "4.4.0"
+  }
 }

--- a/playerViewByMethod/index.js
+++ b/playerViewByMethod/index.js
@@ -350,9 +350,7 @@ export default class VlCPlayerViewByMethod extends Component {
   componentWillUnmount() {
     try{
       let { isFull, Orientation, useNetInfo } = this.props;
-      this.setState({
-        canShowVideo: false
-      });
+      
       if (isFull) {
         this._onCloseFullScreen();
       }

--- a/playerViewByMethod/index.js
+++ b/playerViewByMethod/index.js
@@ -14,10 +14,10 @@ import {
   BackHandler,
   ActivityIndicator,
   Animated,
-  NetInfo,
   Image,
   ScrollView
 } from 'react-native';
+import NetInfo from "@react-native-community/netinfo";
 
 import VLCPlayerView from './VLCPlayerView';
 import PropTypes from 'prop-types';


### PR DESCRIPTION
Avoid warning : "Can't perform a React state update on an unmounted component."

https://github.com/facebook/react/issues/12111#issuecomment-361254441
https://www.robinwieruch.de/react-warning-cant-call-setstate-on-an-unmounted-component

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
    in HomeScreen (at SceneView.js:9)
    in SceneView (at StackViewLayout.tsx:888)
    in RCTView (at View.js:45)
    in View (at StackViewLayout.tsx:887)
    in RCTView (at View.js:45)
    in View (at StackViewLayout.tsx:886)
    in RCTView (at View.js:45)
    in View (at createAnimatedComponent.js:151)
    in AnimatedComponent (at StackViewCard.tsx:93)
    in RCTView (at View.js:45)
    in View (at createAnimatedComponent.js:151)
    in AnimatedComponent (at screens.native.js:59)
    in Screen (at StackViewCard.tsx:80)
    in Card (at createPointerEventsContainer.tsx:95)
    in Container (at StackViewLayout.tsx:971)
    in RCTView (at View.js:45)
    in View (at screens.native.js:83)
    in ScreenContainer (at StackViewLayout.tsx:383)
    in RCTView (at View.js:45)
    in View (at createAnimatedComponent.js:151)
    in AnimatedComponent (at StackViewLayout.tsx:379)
    in PanGestureHandler (at StackViewLayout.tsx:372)
    in StackViewLayout (at withOrientation.js:30)
    in withOrientation (at StackView.tsx:103)
    in RCTView (at View.js:45)
    in View (at Transitioner.tsx:267)
    in Transitioner (at StackView.tsx:40)
    in StackView (at createNavigator.js:61)
    in Navigator (at createKeyboardAwareNavigator.js:12)
    in KeyboardAwareNavigator (at SceneView.js:9)
    in SceneView (at DrawerView.js:149)
    in RCTView (at View.js:45)
    in View (at ResourceSavingScene.js:20)
    in RCTView (at View.js:45)
    in View (at ResourceSavingScene.js:16)
    in ResourceSavingScene (at DrawerView.js:148)
    in RCTView (at View.js:45)
    in View (at screens.native.js:83)
    in ScreenContainer (at DrawerView.js:138)
    in RCTView (at View.js:45)
    in View (at createAnimatedComponent.js:151)
    in AnimatedComponent (at DrawerLayout.js:446)
    in RCTView (at View.js:45)
    in View (at createAnimatedComponent.js:151)
    in AnimatedComponent (at DrawerLayout.js:445)
    in PanGestureHandler (at DrawerLayout.js:501)
    in DrawerLayout (at DrawerView.js:165)
    in DrawerView (at createNavigator.js:61)
    in Navigator (at SceneView.js:9)
```